### PR TITLE
Revise `job.md` documentation

### DIFF
--- a/docs/job.md
+++ b/docs/job.md
@@ -60,7 +60,9 @@ Each job type also includes relevant data.
 {
   'job_id': 'ABC123`
   'job_type': 'documents',
-  'document_id`: 'EPA-HQ-OAR-2011-0028-0108`
+  'page_offset': 3000,
+  'start_date': '12-28-19',
+  'end_date': '1-23-20'
 }  
 ```
 

--- a/docs/job.md
+++ b/docs/job.md
@@ -59,7 +59,7 @@ Each job type also includes relevant data.
 ```
 {
   'job_id': 'ABC123`
-  'job_type': 'document',
+  'job_type': 'documents',
   'document_id`: 'EPA-HQ-OAR-2011-0028-0108`
 }  
 ```

--- a/docs/job.md
+++ b/docs/job.md
@@ -2,23 +2,104 @@
 
 A job defines work that needs to be done by the client.  Jobs are stored in the server and communicated to a client when the `get_work` endpoint is called.
 
+## Job Classes
+
+In the application, each job is represented as an object.  Regardless of type, all jobs contain
+
+* `job_id` - A unique id for each job.
+
+### `DocumentsJob`
+
+* `page_offset` - The page offset (`po`) parameter in the query.  This name mirrors the name in the API, but these names are misleading!  The value represents the offset as measured in *results*.  Since we will download documents in increments of 1000, the `page_offset` value will be 0, 1000, 2000, ...
+* `start_date` - The start date for the search
+* `end_date` - The ending date for the search
+
+
+### `DocumentJob`
+
+* `document_id` - The ID of the document to fetch
+
+### `DocketJob`
+
+* `docket_id` - The ID of the docket to fetch
+
+### `DownloadJob`
+
+Download jobs represent work to download attachments or file formats, both of which are specified in the results of a query to the `document` endpoint.  For example:
+
+```
+"fileFormats": [
+    "https://api.data.gov/regulations/v3/download?documentId=EPA-HQ-OAR-2011-0028-0108&contentType=pdf",
+    "https://api.data.gov/regulations/v3/download?documentId=EPA-HQ-OAR-2011-0028-0108&contentType=html"
+  ],
+```
+
+Because these URLs are already formed, a `downloadJob` simply holds that URL
+
+* `url` - the URL of the attachment or file format
+
+
 ## JSON definition
 
-A job is communicated as a simple JSON object where key names and values are lower case:
+A job is communicated as a JSON object where key names and values are lower case.  All jobs contain:
 
-* `job_type`: This value indicates which endpoint the job refers to.  Possible values are:
+* `job_id`: The id for the job
+* `job_type`: The type of the job.  Possible values are:
   * `documents`
   * `document`
   * `docket`
   * `download`
   * `none` - used to indicate that there is no work to be done.
-* `url`: The url for the job.  This url should contain the server name, path to the end point, and all parameters **except** the API key.
+
+Each job type also includes relevant data.
 
 
-## Examples
+### Example JSON for `documents`
 
 ```
 {
+  'job_id': 'ABC123`
   'job_type': 'document',
-  'url': 'https://api.data.gov/regulations/v3/document.json?documentId=EPA-HQ-OAR-2011-0028-0108'
+  'document_id`: 'EPA-HQ-OAR-2011-0028-0108`
 }  
+```
+
+### Example JSON for `document`
+
+```
+{
+  'job_id': 'ABC123`
+  'job_type': 'document',
+  'document_id`: 'EPA-HQ-OAR-2011-0028-0108`
+}  
+```
+
+### Example JSON for `docket`
+
+```
+{
+  'job_id': 'ABC123`
+  'job_type': 'docket',
+  'docket_id`: 'EPA-HQ-OAR-2011-0028`
+}  
+```
+
+### Example JSON for `download`
+
+```
+{
+  'job_id': 'ABC123`
+  'job_type': 'download',
+  'url`: 'https://api.data.gov/regulations/v3/download?documentId=EPA-HQ-OAR-2011-0028-0108&contentType=pdf`
+}  
+```
+
+### Example JSON for "None" Job
+
+```
+{
+  'job_id': 'ABC123`
+  'job_type': 'none',
+}  
+```
+

--- a/docs/job.md
+++ b/docs/job.md
@@ -41,17 +41,19 @@ Because these URLs are already formed, a `downloadJob` simply holds that URL
 
 ## JSON definition
 
-A job is communicated as a JSON object where key names and values are lower case.  All jobs contain:
+A job is communicated as a JSON object where key names and values are lower case.  
 
-* `job_id`: The id for the job
-* `job_type`: The type of the job.  Possible values are:
+Jobs are identified by the client, but are given a `job_id` by the server.  Therefore, when a job is sent from client to server as a new job, it *does not* contain a `job_id`.
+
+The JSON contains a `job_type` where possible values are:
+
   * `documents`
   * `document`
   * `docket`
   * `download`
   * `none` - used to indicate that there is no work to be done.
 
-Each job type also includes relevant data.
+The JSON also includes relevant data, as defined in the "Job Classes" section, above.
 
 
 ### Example JSON for `documents`


### PR DESCRIPTION
Discussion on Friday indicated that jobs should include different
parameters depending on the type.