### PR TITLE
Add all rule to run tests and static analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 #
 # In PyCharm, you can install a plugin for Makefile support that
 # will use tabs
+all: test static
+
 test:
 	pytest
 


### PR DESCRIPTION

Previously, you had to run `make test` and `make static` as two separate commands.  This new version allows you to simply run `make`, and it will run both.