### PR TITLE
split compute jobs into two different files

### DIFF
--- a/src/c20_client/compute_jobs.py
+++ b/src/c20_client/compute_jobs.py
@@ -1,47 +1,26 @@
 '''
-Compute Jobs from regulations.api
+Compute Jobs offest from documents JSON data
 '''
-import requests
-from c20_client import reggov_api_doc_error
-
-URL = "https://api.data.gov:443/regulations/v3/documents.json?api_key="
 RESULTS_PER_PAGE = 1000
 
 
-def get_number_of_docs(response):
+def get_number_of_docs(documents_data):
     '''
     Return total number of records
     '''
-    number_of_docs = response.get("totalNumRecords")
+    number_of_docs = documents_data.get("totalNumRecords")
     return number_of_docs
 
 
-def get_response_from_api(api_key, start_date, end_date):
-
-    crd = start_date + "-" + end_date
-
-    response = requests.get(URL+api_key+"&crd="+crd)
-
-    if response.status_code == 403:
-        raise reggov_api_doc_error.IncorrectApiKeyException
-    if response.status_code == 429:
-        raise reggov_api_doc_error.ExceedCallLimitException
-
-    return response.json()
-
-
-def compute_jobs(api_key, start_date, end_date):
+def compute_jobs(documents_data):
     '''
-    Computing Jobs for Documents endpoint
+    Computing Jobs offset for Documents endpoint
     '''
-
-    response = get_response_from_api(api_key, start_date, end_date)
-
-    number_of_docs = get_number_of_docs(response)
+    number_of_docs = get_number_of_docs(documents_data)
 
     jobs = []
 
-    for page_offset in range(0, number_of_docs, 1000):
+    for page_offset in range(0, number_of_docs, RESULTS_PER_PAGE):
         job = page_offset  # Line will be used to create DocsJob object
         jobs.append(job)
 

--- a/src/c20_client/get_documents.py
+++ b/src/c20_client/get_documents.py
@@ -6,6 +6,7 @@ from c20_client import reggov_api_doc_error
 
 URL = "https://api.data.gov:443/regulations/v3/documents.json?api_key="
 
+
 def get_response_from_api(api_key, start_date, end_date):
     """
     Get JSON data for documents

--- a/src/c20_client/get_documents.py
+++ b/src/c20_client/get_documents.py
@@ -1,0 +1,22 @@
+"""
+Get JSON data of documents endpoint from regulations.gov
+"""
+import requests
+from c20_client import reggov_api_doc_error
+
+URL = "https://api.data.gov:443/regulations/v3/documents.json?api_key="
+
+def get_response_from_api(api_key, start_date, end_date):
+    """
+    Get JSON data for documents
+    """
+    crd = start_date + "-" + end_date
+
+    response = requests.get(URL+api_key+"&crd="+crd)
+
+    if response.status_code == 403:
+        raise reggov_api_doc_error.IncorrectApiKeyException
+    if response.status_code == 429:
+        raise reggov_api_doc_error.ExceedCallLimitException
+
+    return response.json()


### PR DESCRIPTION
Compute jobs does two different work that can be seperated. This work has been seperate into a way to retieve the endpoint (get_documents.py) and a helper function for the packager (compute_jobs.py)