### PR TITLE
change download packager to have better file names

### DIFF
--- a/src/c20_client/document_packager.py
+++ b/src/c20_client/document_packager.py
@@ -25,15 +25,19 @@ def package_document(document, client_id, job_id):
 
 def get_jobs_list(document):
     jobs_list = []
-    if 'fileFormats' in document:
-        for files in document['fileFormats']:
-            jobs_list.append(
-                json_jobs_helper.get_download_from_document(files))
+    jobs_list += find_file_formats(document)
 
     if 'attachments' in document:
         for attachment in document['attachments']:
-            for files in attachment['fileFormats']:
-                jobs_list.append(
-                    json_jobs_helper.get_download_from_document(files))
+            jobs_list += find_file_formats(attachment)
 
     return jobs_list
+
+
+def find_file_formats(attachment):
+    file_formats = []
+    if 'fileFormats' in attachment:
+        for files in attachment['fileFormats']:
+            file_formats.append(
+                json_jobs_helper.get_download_from_document(files))
+    return file_formats

--- a/src/c20_client/download_packager.py
+++ b/src/c20_client/download_packager.py
@@ -1,12 +1,10 @@
 def package_downloads(download_job, client_id, job_id):
-    docketid = download_job['docketid']
-    documentid = download_job['documentid']
-    folder_name = (download_job['agency'] + "/" + docketid + "/"
-                   + documentid + "/")
+    folder_name = download_job['folder_name']
+    file_name = download_job['file_name'].replace(" ", "_") +\
+        '.' + download_job['file_type']
     data = [{
         'folder_name': folder_name,
-        # may need to change this
-        'file_name': documentid + '.' + download_job['file_type'],
+        'file_name': file_name,
         'data': download_job['data']
     }]
 

--- a/src/c20_client/get_document.py
+++ b/src/c20_client/get_document.py
@@ -13,7 +13,8 @@ def extract_attachments(document):
     attachments = []
     if 'attachments' in document:
         for i in document['attachments']:
-            attachments += i['fileFormats']
+            if 'fileFormats' in i:
+                attachments += i['fileFormats']
         return attachments
     return None
 

--- a/tests/c20_client/test_document_packager.py
+++ b/tests/c20_client/test_document_packager.py
@@ -103,7 +103,7 @@ MANY_ATTACHMENTS_JSON = {
     }, {
         "attachmentOrderNumber": 2,
         'fileFormats': [
-            'URL2',
+            'URL2'
         ]
     }],
     'agencyAcronym': {'value': 'test'},
@@ -115,6 +115,23 @@ MANY_ATTACHMENTS_JSON = {
 @pytest.fixture(name='many_attachments_document')
 def fixture_many_attachments_document():
     response = document_packager.package_document(ATTACHMENT_MANY_FILES_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+NO_ATTACHMENT_JSON = {
+    "attachments": [{
+        "attachmentOrderNumber": 1
+    }],
+    'agencyAcronym': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='no_attachment_document')
+def fixture_no_attachment_document():
+    response = document_packager.package_document(NO_ATTACHMENT_JSON,
                                                   CLIENT_ID, JOB_ID)
     return response
 
@@ -163,3 +180,7 @@ def test_one_attachment_many_fileformats(one_attachment_many_file_document):
 def test_many_attachments(many_attachments_document):
     assert many_attachments_document['jobs'][0]['url'] == 'URL'
     assert many_attachments_document['jobs'][1]['url'] == 'URL2'
+
+
+def test_attachment_with_no_url(no_attachment_document):
+    assert len(no_attachment_document['jobs']) == 0

--- a/tests/c20_client/test_download_packager.py
+++ b/tests/c20_client/test_download_packager.py
@@ -1,16 +1,19 @@
 from c20_client import download_packager
 
 DOWNLOAD_DATA = download_packager.package_downloads(
-    {'data': 'test data', 'agency': 'abc', 'docketid': 'docket-id-3',
-     'documentid': 'document-id-7', 'file_type': 'pdf'}, 1, 2)
+    {'data': 'test data', 'file_name': 'test_file',
+     'file_type': 'pdf', 'folder_name': 'abc/docket-id-3/document-id-7/'},
+    1, 2)
 
 DOWNLOAD_HTML_DATA = download_packager.package_downloads(
-    {'data': 'test data', 'agency': 'abc', 'docketid': 'docket-id-3',
-     'documentid': 'document-id-7', 'file_type': 'htm'}, 1, 2)
+    {'data': 'test data', 'file_name': 'test html file',
+     'file_type': 'htm', 'folder_name': 'abc/docket-id-3/document-id-7/'},
+    1, 2)
 
 DOWNLOAD_EXCEL_DATA = download_packager.package_downloads(
-    {'data': 'test data', 'agency': 'abc', 'docketid': 'docket-id-3',
-     'documentid': 'document-id-7', 'file_type': 'xlsx'}, 1, 2)
+    {'data': 'test data', 'file_name': 'test_excel file',
+     'folder_name': 'abc/docket-id-3/document-id-7/', 'file_type': 'xlsx'},
+    1, 2)
 
 
 def test_client_id():
@@ -27,15 +30,16 @@ def test_folder_name():
 
 
 def test_file_name():
-    assert DOWNLOAD_DATA['data'][0]['file_name'] == 'document-id-7.pdf'
+    assert DOWNLOAD_DATA['data'][0]['file_name'] == 'test_file.pdf'
 
 
 def test_html_file_name():
-    assert DOWNLOAD_HTML_DATA['data'][0]['file_name'] == 'document-id-7.htm'
+    assert DOWNLOAD_HTML_DATA['data'][0]['file_name'] == 'test_html_file.htm'
 
 
 def test_excel_file_name():
-    assert DOWNLOAD_EXCEL_DATA['data'][0]['file_name'] == 'document-id-7.xlsx'
+    assert DOWNLOAD_EXCEL_DATA['data'][0]['file_name'] ==\
+           'test_excel_file.xlsx'
 
 
 def test_data():


### PR DESCRIPTION
* change the download job to no longer have the document and docket id, nor have the agency
* add folder_name to the download job
* add file_name to the download job
* change attachments to check for no file formats