### PR TITLE
Support running Makefile in PyCharm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@
 #
 # In PyCharm, you can install a plugin for Makefile support that
 # will use tabs
+export PATH:=${PWD}/.venv/bin:${PATH};
+
 all: test static
 
 test:
-	pytest
+	pytest;
 
 static:
-	flake8 src tests
-	pycodestyle src tests
-	pylint src tests
+	flake8 src tests;
+	pycodestyle src tests;
+	pylint src tests;
 
 clean:
 	rm -rf htmlcov


### PR DESCRIPTION
When PyCharm runs `make`, it does it in a new shell, which means that
the virtual environment is NOT active.  To get around this, we can
modify the `PATH` variable in the `Makefile` to manually add the
directory where the Python binaries live.

Unfortunately, this isn't enough - PyCharm still gave a "No such file
or directory" error after I changed the `PATH`.  [This](https://stackoverflow.com/questions/21708839/problems-setting-path-in-makefile)
StackOverflow question was related, and a proposed solution was to add
a `;` after each command to use something called the "slow path."

By adding both the `PATH` modification and the `;`'s, I am now able
to run make in PyCharm.  When you do so, it will run tests (with coverage!)
along with all our static analysis tools.