### PR TITLE
Download endpoint edit

### DIFF
--- a/src/c20_server/job.py
+++ b/src/c20_server/job.py
@@ -30,6 +30,8 @@ class DocketJob(namedtuple('DocketJob',
 
 class DownloadJob(namedtuple('DownloadJob',
                              ['job_id',
+                              'folder_name',
+                              'file_name',
                               'url']
                              )):
     pass

--- a/src/c20_server/job.py
+++ b/src/c20_server/job.py
@@ -32,6 +32,7 @@ class DownloadJob(namedtuple('DownloadJob',
                              ['job_id',
                               'folder_name',
                               'file_name',
+                              'file_type',
                               'url']
                              )):
     pass

--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -82,7 +82,9 @@ def add_specific_job_data(record, json_job):
         return DocketJob(record.job_id, docket_id)
 
     if record.job_type == DOWNLOAD:
+        folder_name = json_job["folder_name"]
+        file_name = json_job["file_name"]
         url = json_job["url"]
-        return DownloadJob(record.job_id, url)
+        return DownloadJob(record.job_id, folder_name, file_name, url)
 
     raise job_translator_errors.UnrecognizedJobTypeException

--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -102,5 +102,6 @@ def create_docket_job(record, json_job):
 def create_download_job(record, json_job):
     folder_name = json_job["folder_name"]
     file_name = json_job["file_name"]
+    file_type = json_job["file_type"]
     url = json_job["url"]
-    return DownloadJob(record.job_id, folder_name, file_name, url)
+    return DownloadJob(record.job_id, folder_name, file_name, file_type, url)

--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -68,23 +68,39 @@ def json_to_job(json_job):
 
 def add_specific_job_data(record, json_job):
     if record.job_type == DOCUMENTS:
-        page_offset = json_job["page_offset"]
-        start_date = json_job["start_date"]
-        end_date = json_job["end_date"]
-        return DocumentsJob(record.job_id, page_offset, start_date, end_date)
+        return create_documents_job(record, json_job)
 
     if record.job_type == DOCUMENT:
-        document_id = json_job["document_id"]
-        return DocumentJob(record.job_id, document_id)
+        return create_document_job(record, json_job)
 
     if record.job_type == DOCKET:
-        docket_id = json_job["docket_id"]
-        return DocketJob(record.job_id, docket_id)
+        return create_docket_job(record, json_job)
 
     if record.job_type == DOWNLOAD:
-        folder_name = json_job["folder_name"]
-        file_name = json_job["file_name"]
-        url = json_job["url"]
-        return DownloadJob(record.job_id, folder_name, file_name, url)
+        return create_download_job(record, json_job)
 
     raise job_translator_errors.UnrecognizedJobTypeException
+
+
+def create_documents_job(record, json_job):
+    page_offset = json_job["page_offset"]
+    start_date = json_job["start_date"]
+    end_date = json_job["end_date"]
+    return DocumentsJob(record.job_id, page_offset, start_date, end_date)
+
+
+def create_document_job(record, json_job):
+    document_id = json_job["document_id"]
+    return DocumentJob(record.job_id, document_id)
+
+
+def create_docket_job(record, json_job):
+    docket_id = json_job["docket_id"]
+    return DocketJob(record.job_id, docket_id)
+
+
+def create_download_job(record, json_job):
+    folder_name = json_job["folder_name"]
+    file_name = json_job["file_name"]
+    url = json_job["url"]
+    return DownloadJob(record.job_id, folder_name, file_name, url)

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -38,7 +38,7 @@ def make_first_download_job():
     url = "https://.../download?documentId=...&contentType=pdf"
     return DownloadJob('job01',
                        "CMS/CMS-2005/",
-                       "title_of_file.pdf",
+                       "title_of_file",
                        "pdf",
                        url)
 

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -15,23 +15,32 @@ def make_job_queue():
 
 @pytest.fixture(name='documents_job')
 def make_first_documents_job():
-    return DocumentsJob('job01', 1000, '2020-1-28', '2020-5-6')
+    return DocumentsJob('job01',
+                        1000,
+                        '2020-1-28',
+                        '2020-5-6')
 
 
 @pytest.fixture(name='document_job')
 def make_first_document_job():
-    return DocumentJob('job01', 'EPA-HQ-OAR-2011-0028-0108')
+    return DocumentJob('job01',
+                       'EPA-HQ-OAR-2011-0028-0108')
 
 
 @pytest.fixture(name='docket_job')
 def make_first_docket_job():
-    return DocketJob('job01', 'EPA-HQ-OAR-2011-0028')
+    return DocketJob('job01',
+                     'EPA-HQ-OAR-2011-0028')
 
 
 @pytest.fixture(name='download_job')
 def make_first_download_job():
     url = "https://.../download?documentId=...&contentType=pdf"
-    return DownloadJob('job01', "CMS/CMS-2005/", "title_of_file.pdf", url)
+    return DownloadJob('job01',
+                       "CMS/CMS-2005/",
+                       "title_of_file.pdf",
+                       "pdf",
+                       url)
 
 
 def test_one_job_added_is_returned_by_get(job_queue):

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -31,7 +31,7 @@ def make_first_docket_job():
 @pytest.fixture(name='download_job')
 def make_first_download_job():
     url = "https://.../download?documentId=...&contentType=pdf"
-    return DownloadJob('job01', url)
+    return DownloadJob('job01', "CMS/CMS-2005/", "title_of_file.pdf", url)
 
 
 def test_one_job_added_is_returned_by_get(job_queue):

--- a/tests/test_job_translator.py
+++ b/tests/test_job_translator.py
@@ -68,7 +68,7 @@ def test_download_job_to_json():
     job_example = \
         DownloadJob("2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
                     "CMS/CMS-2005/",
-                    "title_of_file.pdf",
+                    "title_of_file",
                     "pdf",
                     url)
 
@@ -77,7 +77,7 @@ def test_download_job_to_json():
     job_json_expected = \
         {"job_id": "2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
          "folder_name": "CMS/CMS-2005/",
-         "file_name": "title_of_file.pdf",
+         "file_name": "title_of_file",
          "file_type": "pdf",
          "url": url,
          "job_type": "download"}
@@ -129,7 +129,7 @@ def test_single_download_json_to_job():
         {
             "job_type": "download",
             "folder_name": "CMS/CMS-2005/",
-            "file_name": "title_of_file.pdf",
+            "file_name": "title_of_file",
             "file_type": "pdf",
             "url": url
         }
@@ -137,7 +137,7 @@ def test_single_download_json_to_job():
     download_job = \
         job.DownloadJob(test_job[0],
                         "CMS/CMS-2005/",
-                        "title_of_file.pdf",
+                        "title_of_file",
                         "pdf",
                         url)
     assert test_job == download_job
@@ -248,21 +248,21 @@ def test_handle_document_return_data():
                 {
                     "job_type": "download",
                     "folder_name": "CMS/CMS-2005/",
-                    "file_name": "CMS_file.pdf",
+                    "file_name": "CMS_file",
                     "file_type": "pdf",
                     "url": url1
                 },
                 {
                     "job_type": "download",
                     "folder_name": "DMS/DMS-2050/",
-                    "file_name": "DMS_file.html",
+                    "file_name": "DMS_file",
                     "file_type": "html",
                     "url": url2
                 },
                 {
                     "job_type": "download",
                     "folder_name": "LAO/LAO-1450/",
-                    "file_name": "LAO_file.excel",
+                    "file_name": "LAO_file",
                     "file_type": "excel",
                     "url": url3
                 },
@@ -277,19 +277,19 @@ def test_handle_document_return_data():
         job.DownloadJob(
             job_id=test_job[0][0],
             folder_name="CMS/CMS-2005/",
-            file_name="CMS_file.pdf",
+            file_name="CMS_file",
             file_type="pdf",
             url=url1),
         job.DownloadJob(
             job_id=test_job[1][0],
             folder_name="DMS/DMS-2050/",
-            file_name="DMS_file.html",
+            file_name="DMS_file",
             file_type="html",
             url=url2),
         job.DownloadJob(
             job_id=test_job[2][0],
             folder_name="LAO/LAO-1450/",
-            file_name="LAO_file.excel",
+            file_name="LAO_file",
             file_type="excel",
             url=url3)
     ]

--- a/tests/test_job_translator.py
+++ b/tests/test_job_translator.py
@@ -69,6 +69,7 @@ def test_download_job_to_json():
         DownloadJob("2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
                     "CMS/CMS-2005/",
                     "title_of_file.pdf",
+                    "pdf",
                     url)
 
     job_json = job_translator.job_to_json(job_example)
@@ -77,6 +78,7 @@ def test_download_job_to_json():
         {"job_id": "2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
          "folder_name": "CMS/CMS-2005/",
          "file_name": "title_of_file.pdf",
+         "file_type": "pdf",
          "url": url,
          "job_type": "download"}
     job_json_expected = json.dumps(job_json_expected)
@@ -128,6 +130,7 @@ def test_single_download_json_to_job():
             "job_type": "download",
             "folder_name": "CMS/CMS-2005/",
             "file_name": "title_of_file.pdf",
+            "file_type": "pdf",
             "url": url
         }
     test_job = job_translator.json_to_job(json_example)
@@ -135,6 +138,7 @@ def test_single_download_json_to_job():
         job.DownloadJob(test_job[0],
                         "CMS/CMS-2005/",
                         "title_of_file.pdf",
+                        "pdf",
                         url)
     assert test_job == download_job
 
@@ -245,18 +249,21 @@ def test_handle_document_return_data():
                     "job_type": "download",
                     "folder_name": "CMS/CMS-2005/",
                     "file_name": "CMS_file.pdf",
+                    "file_type": "pdf",
                     "url": url1
                 },
                 {
                     "job_type": "download",
                     "folder_name": "DMS/DMS-2050/",
-                    "file_name": "DMS_file.pdf",
+                    "file_name": "DMS_file.html",
+                    "file_type": "html",
                     "url": url2
                 },
                 {
                     "job_type": "download",
                     "folder_name": "LAO/LAO-1450/",
-                    "file_name": "LAO_file.pdf",
+                    "file_name": "LAO_file.excel",
+                    "file_type": "excel",
                     "url": url3
                 },
 
@@ -271,16 +278,19 @@ def test_handle_document_return_data():
             job_id=test_job[0][0],
             folder_name="CMS/CMS-2005/",
             file_name="CMS_file.pdf",
+            file_type="pdf",
             url=url1),
         job.DownloadJob(
             job_id=test_job[1][0],
             folder_name="DMS/DMS-2050/",
-            file_name="DMS_file.pdf",
+            file_name="DMS_file.html",
+            file_type="html",
             url=url2),
         job.DownloadJob(
             job_id=test_job[2][0],
             folder_name="LAO/LAO-1450/",
-            file_name="LAO_file.pdf",
+            file_name="LAO_file.excel",
+            file_type="excel",
             url=url3)
     ]
     assert test_job == job_list

--- a/tests/test_job_translator.py
+++ b/tests/test_job_translator.py
@@ -67,12 +67,16 @@ def test_download_job_to_json():
            ?documentId=CMS-2005-0001-0001&contentType=pdf"
     job_example = \
         DownloadJob("2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
+                    "CMS/CMS-2005/",
+                    "title_of_file.pdf",
                     url)
 
     job_json = job_translator.job_to_json(job_example)
 
     job_json_expected = \
         {"job_id": "2aae0fca-bf7d-4444-ab9b-0120414aa0b5",
+         "folder_name": "CMS/CMS-2005/",
+         "file_name": "title_of_file.pdf",
          "url": url,
          "job_type": "download"}
     job_json_expected = json.dumps(job_json_expected)
@@ -122,11 +126,15 @@ def test_single_download_json_to_job():
     json_example = \
         {
             "job_type": "download",
+            "folder_name": "CMS/CMS-2005/",
+            "file_name": "title_of_file.pdf",
             "url": url
         }
     test_job = job_translator.json_to_job(json_example)
     download_job = \
         job.DownloadJob(test_job[0],
+                        "CMS/CMS-2005/",
+                        "title_of_file.pdf",
                         url)
     assert test_job == download_job
 
@@ -235,14 +243,20 @@ def test_handle_document_return_data():
             "jobs": [
                 {
                     "job_type": "download",
+                    "folder_name": "CMS/CMS-2005/",
+                    "file_name": "CMS_file.pdf",
                     "url": url1
                 },
                 {
                     "job_type": "download",
+                    "folder_name": "DMS/DMS-2050/",
+                    "file_name": "DMS_file.pdf",
                     "url": url2
                 },
                 {
                     "job_type": "download",
+                    "folder_name": "LAO/LAO-1450/",
+                    "file_name": "LAO_file.pdf",
                     "url": url3
                 },
 
@@ -255,12 +269,18 @@ def test_handle_document_return_data():
     job_list = [
         job.DownloadJob(
             job_id=test_job[0][0],
+            folder_name="CMS/CMS-2005/",
+            file_name="CMS_file.pdf",
             url=url1),
         job.DownloadJob(
             job_id=test_job[1][0],
+            folder_name="DMS/DMS-2050/",
+            file_name="DMS_file.pdf",
             url=url2),
         job.DownloadJob(
             job_id=test_job[2][0],
+            folder_name="LAO/LAO-1450/",
+            file_name="LAO_file.pdf",
             url=url3)
     ]
     assert test_job == job_list


### PR DESCRIPTION
This pull request will add the functionality that Anthony requested for a download job to contain the two new additional fields of folder_name and file_name when the get_job/ endpoint is called.

I've added the two fields to the Download Job object and added them into the job_translator code when the Download Jobs are created.
