### PR TITLE
Add host address specification

### DIFF
--- a/src/c20_server/flask_server.py
+++ b/src/c20_server/flask_server.py
@@ -47,4 +47,4 @@ if __name__ == '__main__':
     JOB_MANAGER = JobManager(database=REDIS)
     JOB_MANAGER.add_job(DocumentsJob('1', 0, '12/28/19', '1/23/20'))
     APP = create_app(JOB_MANAGER)
-    APP.run()
+    APP.run(host='0.0.0.0')


### PR DESCRIPTION
The specification for host='0.0.0.0' will open up the flask server to run on our deploy server's public IP address. Previously it was run with the default parameter of localhost or 127.0.0.1 which was causing outside connections to be unable to connect.