### PR TITLE
Server-side user id endpoint

### DIFF
--- a/src/c20_server/database.py
+++ b/src/c20_server/database.py
@@ -15,6 +15,18 @@ class Database:
         except redis.exceptions.ConnectionError:
             return False
 
+    def initialize_user_ids(self):
+        if self.r_database.get('user_id') is None:
+            self.r_database.set('user_id', 0)
+
+    def set_new_user_id(self, id_number):
+        self.r_database.set('user_id', id_number)
+
+    def get_new_user_id(self):
+        prev_user_id = self.r_database.get('user_id')
+        user_id = prev_user_id + 1
+        return user_id
+
 
 class MockDatabase(Database):
 

--- a/src/c20_server/flask_server.py
+++ b/src/c20_server/flask_server.py
@@ -1,6 +1,6 @@
 import json
-import fakeredis
 import uuid
+import fakeredis
 from flask import Flask, request
 from c20_server.user import User
 from c20_server.job import DocumentsJob

--- a/src/c20_server/flask_server.py
+++ b/src/c20_server/flask_server.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-import fakeredis
 import redis
 from flask import Flask, request
 from c20_server.user import User

--- a/src/c20_server/flask_server.py
+++ b/src/c20_server/flask_server.py
@@ -1,5 +1,6 @@
 import json
 import fakeredis
+import uuid
 from flask import Flask, request
 from c20_server.user import User
 from c20_server.job import DocumentsJob
@@ -12,6 +13,13 @@ def create_app(job_manager):
 
     # Note: endpoint names begin with an "_" so that Pylint does not complain
     # about unused functions.
+
+    @app.route('/get_user_id')
+    def _get_client_id():
+        user_id = str(uuid.uuid4())
+        print('Server: Sending user_id: ' + user_id)
+        user_id_json = {'user_id': user_id}
+        return user_id_json
 
     @app.route('/get_job')
     def _get_job():

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -1,7 +1,7 @@
 import json
+from uuid import UUID
 import fakeredis
 import pytest
-from uuid import UUID
 from c20_server.flask_server import create_app
 from c20_server.mock_job_manager import MockJobManager
 from c20_server.job import DocumentsJob

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -1,7 +1,7 @@
 import json
-
 import fakeredis
 import pytest
+from uuid import UUID
 from c20_server.flask_server import create_app
 from c20_server.mock_job_manager import MockJobManager
 from c20_server.job import DocumentsJob
@@ -25,6 +25,17 @@ def client_fixture(manager):
     app = create_app(manager)
     app.config['TESTING'] = True
     return app.test_client()
+
+
+def test_return_user_id_is_uuid(manager):
+    mock_job_manager = manager
+    app = create_app(mock_job_manager)
+    app.config['TESTING'] = True
+    client = app.test_client()
+    result = client.get('/get_user_id')
+    json_ = json.loads(result.data)
+    is_uuid = UUID(json_['user_id'], version=4)
+    assert is_uuid
 
 
 def test_return_result_success(manager):

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -27,9 +27,8 @@ def client_fixture(job_manager):
     return app.test_client()
 
 
-<<<<<<< HEAD
-def test_return_user_id_is_uuid(manager):
-    mock_job_manager = manager
+def test_return_user_id_is_uuid(job_manager):
+    mock_job_manager = job_manager
     app = create_app(mock_job_manager)
     app.config['TESTING'] = True
     client = app.test_client()
@@ -39,13 +38,8 @@ def test_return_user_id_is_uuid(manager):
     assert is_uuid
 
 
-def test_return_result_success(manager):
-    mock_job_manager = manager
-    app = create_app(mock_job_manager)
-=======
 def test_return_result_success(job_manager):
     app = create_app(job_manager)
->>>>>>> c08f706971ed365e5fd94146d5a0a6a89b6021bc
     app.config['TESTING'] = True
     client = app.test_client()
 

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -1,5 +1,4 @@
 import json
-from uuid import UUID
 from unittest.mock import patch
 import fakeredis
 import pytest
@@ -29,15 +28,14 @@ def client_fixture(job_manager):
     return app.test_client()
 
 
-def test_return_user_id_is_uuid(job_manager):
-    mock_job_manager = job_manager
-    app = create_app(mock_job_manager)
+def test_initialize_user_ids(job_manager):
+    data_repository_spy = SpyDataRepository()
+    app = create_app(job_manager, data_repository_spy)
     app.config['TESTING'] = True
     client = app.test_client()
     result = client.get('/get_user_id')
     json_ = json.loads(result.data)
-    is_uuid = UUID(json_['user_id'], version=4)
-    assert is_uuid
+    assert json_['user_id'] == 0
 
 
 def test_return_result_success(job_manager):


### PR DESCRIPTION
Here is the beginning of an implementation for the creation and usage of user ids that can be returned to a running client.

The test created for this checks the return data from the '/get_user_id' endpoint and asserts that the 'user_id' returned is a valid uuid4 type.

This currently does not use Redis and this pull request is not yet ready to be merged.