### PR TITLE
Client id manager

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,1 @@
+Every Client will have a client id. For a new client, it must get an id by quering the "/get_user_id". The server sends the client a JSON response with the key `user_id` for the id value. The client id must be stored as an environment variable in the .env file with the key `CLIENT_ID`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask
 pylint
 pytest
 pytest-cov
+pytest-mock
 python-dotenv
 requests
 requests-mock

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -36,5 +36,5 @@ def save_client_env_variable(client_id):
     Will create file if does not already exist
     """
     writer = open('.env', 'a+')
-    writer.append("CLIENT_ID=" + str(client_id) + "\n")
+    writer.write("CLIENT_ID=" + str(client_id) + "\n")
     writer.close()

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -1,0 +1,30 @@
+"""
+File used to check for an environment variable for id and to
+get an id form server and assign the id to the enviornment
+variable if the environment variable does not yet exist
+"""
+from os import getenv
+import requests
+
+
+def request_id():
+    """
+    Ask Moravian server endpoint for id
+    Returns an id
+    """
+    response = requests.get('http://capstone.cs.moravian.edu/get_client_id')
+    return response.json()['client_id']
+
+
+def client_has_id():
+    """
+    Checks for the client id as a .env variable called CLIENT_ID
+    """
+    client_id = getenv("CLIENT_ID")
+
+     # Client does not yet have an id
+    if client_id is None:
+        return False
+
+    # Client has an id assigned
+    return True

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -43,11 +43,8 @@ class IdManager():
         """
         Checks for the client id as a .env variable called CLIENT_ID
         """
-        print('checking')
         client_id = self.get_id()
-        print('HAS IT')
-        print(client_id)
-        print('^^^^^^^^^^^^^')
+
         # Client does not yet have an id
         if client_id is None:
             return False
@@ -69,5 +66,4 @@ class IdManager():
         """
         Gets the id from the env variable
         """
-        print ('------>' + str(getenv("CLIENT_ID")) + '<---------')
         return getenv("CLIENT_ID")

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -22,9 +22,19 @@ def client_has_id():
     """
     client_id = getenv("CLIENT_ID")
 
-     # Client does not yet have an id
+    # Client does not yet have an id
     if client_id is None:
         return False
 
     # Client has an id assigned
     return True
+
+
+def save_client_env_variable(client_id):
+    """
+    Append client id to the environment varibale file
+    Will create file if does not already exist
+    """
+    writer = open('.env', 'a+')
+    writer.append("CLIENT_ID=" + str(client_id) + "\n")
+    writer.close()

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -18,6 +18,7 @@ class ClientManager():
         load_dotenv()
         self.client_id = getenv("CLIENT_ID")
         self.api_key = getenv("API_KEY")
+        self.check_for_id()
 
     def reset_keys(self):
         """
@@ -26,6 +27,7 @@ class ClientManager():
         """
         self.client_id = getenv("CLIENT_ID")
         self.api_key = getenv("API_KEY")
+
 
     def check_for_id(self):
         """

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -15,8 +15,8 @@ def request_id():
     Ask Moravian server endpoint for id
     Returns an id
     """
-    response = requests.get('http://capstone.cs.moravian.edu/get_client_id')
-    return response.json()['client_id']
+    response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
+    return response.json()['user_id']
 
 
 def client_has_id():

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -9,35 +9,56 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-
-def request_id():
+class IdManager():
     """
-    Ask Moravian server endpoint for id
-    Returns an id
+    Manages id functions for getting, saving, and
+    checking the existence of an id
     """
-    response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
-    return response.json()['user_id']
+
+    def __init__(self):
+        """
+        Initialize the database
+        Checks for an id, if not exist the Manager makes
+        the request for an id and saves it
+        """
+        if not self.client_has_id():
+            self.save_client_env_variable(self.request_id)
 
 
-def client_has_id():
-    """
-    Checks for the client id as a .env variable called CLIENT_ID
-    """
-    client_id = getenv("CLIENT_ID")
-
-    # Client does not yet have an id
-    if client_id is None:
-        return False
-
-    # Client has an id assigned
-    return True
+    def request_id(self):
+        """
+        Ask Moravian server endpoint for id
+        Returns an id
+        """
+        response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
+        return response.json()['user_id']
 
 
-def save_client_env_variable(client_id):
-    """
-    Append client id to the environment varibale file
-    Will create file if does not already exist
-    """
-    writer = open('.env', 'a+')
-    writer.write("CLIENT_ID=" + str(client_id) + "\n")
-    writer.close()
+    def client_has_id(self):
+        """
+        Checks for the client id as a .env variable called CLIENT_ID
+        """
+        client_id = self.get_id
+
+        # Client does not yet have an id
+        if client_id is None:
+            return False
+
+        # Client has an id assigned
+        return True
+
+
+    def save_client_env_variable(self, client_id):
+        """
+        Append client id to the environment varibale file
+        Will create file if does not already exist
+        """
+        writer = open('.env', 'a+')
+        writer.write("CLIENT_ID=" + str(client_id) + "\n")
+        writer.close()
+
+    def get_id(self):
+        """
+        Gets the id from the env variable
+        """
+        return getenv("CLIENT_ID")

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -46,7 +46,7 @@ class ClientManager():
                 'http://capstone.cs.moravian.edu/get_user_id')
         except Exception:
             raise NoConnectionError
-        
+
         self.client_id = response.json()['user_id']
         return self.client_id
 
@@ -60,6 +60,7 @@ class ClientManager():
 
         # Client has an id assigned
         return True
+
 
 def save_client_env_variable(client_id):
     """

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -43,8 +43,11 @@ class IdManager():
         """
         Checks for the client id as a .env variable called CLIENT_ID
         """
+        print('checking')
         client_id = self.get_id()
-
+        print('HAS IT')
+        print(client_id)
+        print('^^^^^^^^^^^^^')
         # Client does not yet have an id
         if client_id is None:
             return False
@@ -66,4 +69,5 @@ class IdManager():
         """
         Gets the id from the env variable
         """
+        print ('------>' + str(getenv("CLIENT_ID")) + '<---------')
         return getenv("CLIENT_ID")

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -10,6 +10,7 @@ from c20_client.connection_error import NoConnectionError
 
 load_dotenv()
 
+
 class IdManager():
     """
     Manages id functions for getting, saving, and
@@ -23,8 +24,7 @@ class IdManager():
         """
         # If client does not have an id
         if not self.client_has_id():
-            self.save_client_env_variable(self.request_id)
-
+            self.save_client_env_variable(self.request_id())
 
     def request_id(self):
         """
@@ -32,12 +32,12 @@ class IdManager():
         Returns an id
         """
         try:
-            response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
+            response = requests.get(
+                'http://capstone.cs.moravian.edu/get_user_id')
         except Exception:
             raise NoConnectionError
 
         return response.json()['user_id']
-
 
     def client_has_id(self):
         """
@@ -51,7 +51,6 @@ class IdManager():
 
         # Client has an id assigned
         return True
-
 
     def save_client_env_variable(self, client_id):
         """

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -28,7 +28,6 @@ class ClientManager():
         self.client_id = getenv("CLIENT_ID")
         self.api_key = getenv("API_KEY")
 
-
     def check_for_id(self):
         """
         Checks for an id, if not exist the Manager makes

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -8,23 +8,33 @@ import requests
 from dotenv import load_dotenv
 from c20_client.connection_error import NoConnectionError
 
-load_dotenv()
 
-
-class IdManager():
+class ClientManager():
     """
     Manages id functions for getting, saving, and
     checking the existence of an id
     """
+    def __init__(self):
+        load_dotenv()
+        self.client_id = getenv("CLIENT_ID")
+        self.api_key = getenv("API_KEY")
 
-    def check(self):
+    def reset_keys(self):
+        """
+        Function is used mainly for testing purposes.
+        Sets keys to currently loaded enviornment variables.
+        """
+        self.client_id = getenv("CLIENT_ID")
+        self.api_key = getenv("API_KEY")
+
+    def check_for_id(self):
         """
         Checks for an id, if not exist the Manager makes
         the request for an id and saves it
         """
         # If client does not have an id
         if not self.client_has_id():
-            self.save_client_env_variable(self.request_id())
+            save_client_env_variable(self.request_id())
 
     def request_id(self):
         """
@@ -36,33 +46,26 @@ class IdManager():
                 'http://capstone.cs.moravian.edu/get_user_id')
         except Exception:
             raise NoConnectionError
-
-        return response.json()['user_id']
+        
+        self.client_id = response.json()['user_id']
+        return self.client_id
 
     def client_has_id(self):
         """
         Checks for the client id as a .env variable called CLIENT_ID
         """
-        client_id = self.get_id()
-
         # Client does not yet have an id
-        if client_id is None:
+        if self.client_id is None:
             return False
 
         # Client has an id assigned
         return True
 
-    def save_client_env_variable(self, client_id):
-        """
-        Append client id to the environment varibale file
-        Will create file if does not already exist
-        """
-        writer = open('.env', 'a+')
-        writer.write("CLIENT_ID=" + str(client_id) + "\n")
-        writer.close()
-
-    def get_id(self):
-        """
-        Gets the id from the env variable
-        """
-        return getenv("CLIENT_ID")
+def save_client_env_variable(client_id):
+    """
+    Append client id to the environment varibale file
+    Will create file if does not already exist
+    """
+    writer = open('.env', 'a+')
+    writer.write("CLIENT_ID=" + str(client_id) + "\n")
+    writer.close()

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -6,6 +6,7 @@ variable if the environment variable does not yet exist
 from os import getenv
 import requests
 from dotenv import load_dotenv
+from c20_client.connection_error import NoConnectionError
 
 load_dotenv()
 
@@ -15,12 +16,12 @@ class IdManager():
     checking the existence of an id
     """
 
-    def __init__(self):
+    def check(self):
         """
-        Initialize the database
         Checks for an id, if not exist the Manager makes
         the request for an id and saves it
         """
+        # If client does not have an id
         if not self.client_has_id():
             self.save_client_env_variable(self.request_id)
 
@@ -30,7 +31,11 @@ class IdManager():
         Ask Moravian server endpoint for id
         Returns an id
         """
-        response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
+        try:
+            response = requests.get('http://capstone.cs.moravian.edu/get_user_id')
+        except Exception:
+            raise NoConnectionError
+
         return response.json()['user_id']
 
 
@@ -38,7 +43,7 @@ class IdManager():
         """
         Checks for the client id as a .env variable called CLIENT_ID
         """
-        client_id = self.get_id
+        client_id = self.get_id()
 
         # Client does not yet have an id
         if client_id is None:

--- a/src/c20_client/get_client_id.py
+++ b/src/c20_client/get_client_id.py
@@ -5,6 +5,9 @@ variable if the environment variable does not yet exist
 """
 from os import getenv
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def request_id():

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -54,7 +54,7 @@ def test_id_exist_in_environment():
     assert MANAGER.get_id() == CLIENT_ID
 
 
-def tests_check_in_environment(mocker):
+def tests_check_in_environment():
     with requests_mock.Mocker() as mock:
         mock.get('http://capstone.cs.moravian.edu/get_user_id',
                  json={'user_id': CLIENT_ID})

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -28,12 +28,11 @@ def test_write_env_variable(mocker):
 
 
 def test_id_not_exist_in_env():
-    print(MANAGER.get_id())
-    assert MANAGER.get_id() is None
     assert not MANAGER.client_has_id()
+    assert MANAGER.get_id() is None
 
 
 def test_id_exist_in_environment():
     environ['CLIENT_ID'] = CLIENT_ID
-    assert MANAGER.get_id() == CLIENT_ID
     assert MANAGER.client_has_id()
+    assert MANAGER.get_id() == CLIENT_ID

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,7 +1,8 @@
+from os import environ
 import requests_mock
 from unittest.mock import mock_open
 import pytest
-from c20_client.get_client_id import request_id, save_client_env_variable
+from c20_client.get_client_id import request_id, save_client_env_variable, client_has_id
 
 CLIENT_ID = '1234'
 
@@ -17,8 +18,18 @@ def test_request_id_call():
         assert 'capstone' in history[0].url
         assert client_id == CLIENT_ID
 
+
 def test_write_env_variable(mocker):
     file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
     save_client_env_variable(CLIENT_ID)
     file_mock.assert_called_once_with('.env', 'a+')
     file_mock().write.assert_called_once_with("CLIENT_ID=" + CLIENT_ID + "\n")
+
+
+def test_id_not_exist_in_env():
+    assert not client_has_id()
+
+
+def test_id_exist_in_environment():
+    environ['CLIENT_ID'] = CLIENT_ID
+    assert client_has_id()

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,21 +1,18 @@
 from os import environ
 from unittest.mock import mock_open
 import requests_mock
-from c20_client.get_client_id import (
-    request_id,
-    save_client_env_variable,
-    client_has_id
-)
+from c20_client.get_client_id import IdManager
 
 CLIENT_ID = '1234'
+MANAGER = IdManager()
 
 
 def test_request_id_call():
     with requests_mock.Mocker() as mock:
-        mock.get('http://capstone.cs.moravian.edu/get_client_id',
-                 json={'client_id': CLIENT_ID})
+        mock.get('http://capstone.cs.moravian.edu/get_user_id',
+                 json={'user_id': CLIENT_ID})
 
-        client_id = request_id()
+        client_id = MANAGER.request_id()
         history = mock.request_history
 
         assert len(history) == 1
@@ -25,15 +22,18 @@ def test_request_id_call():
 
 def test_write_env_variable(mocker):
     file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
-    save_client_env_variable(CLIENT_ID)
+    MANAGER.save_client_env_variable(CLIENT_ID)
     file_mock.assert_called_once_with('.env', 'a+')
     file_mock().write.assert_called_once_with("CLIENT_ID=" + CLIENT_ID + "\n")
 
 
 def test_id_not_exist_in_env():
-    assert not client_has_id()
+    print(MANAGER.get_id())
+    assert MANAGER.get_id() is None
+    assert not MANAGER.client_has_id()
 
 
 def test_id_exist_in_environment():
     environ['CLIENT_ID'] = CLIENT_ID
-    assert client_has_id()
+    assert MANAGER.get_id() == CLIENT_ID
+    assert MANAGER.client_has_id()

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,0 +1,18 @@
+import requests_mock
+from mock import mock_open, patch, MagicMock
+import pytest
+from c20_client.get_client_id import request_id, client_has_id
+
+CLIENT_ID = 1234
+
+def test_request_id_call():
+    with requests_mock.Mocker() as mock:
+        mock.get('http://capstone.cs.moravian.edu/get_client_id',
+                 json={'client_id': CLIENT_ID})
+
+        client_id = request_id()
+        history = mock.request_history
+
+        assert len(history) == 1
+        assert 'capstone' in history[0].url
+        assert client_id == CLIENT_ID

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -13,22 +13,25 @@ API_KEY = 'xxxx-xyz-xxxx'
 
 @pytest.fixture(name="manager")
 def fixture_client_manager_unset(mocker):
-    mocker.patch('c20_client.get_client_id.open', mock_open())
+    with requests_mock.Mocker() as mock:
+        mock.get('http://capstone.cs.moravian.edu/get_user_id',
+                 json={'user_id': CLIENT_ID})
+        mocker.patch('c20_client.get_client_id.open', mock_open())
 
-    manager = ClientManager()
+        manager = ClientManager()
 
-    # Delete the environment variable if it is loaded
-    if getenv('CLIENT_ID') is not None:
-        del environ['CLIENT_ID']
+        # Delete the environment variable if it is loaded
+        if getenv('CLIENT_ID') is not None:
+            del environ['CLIENT_ID']
 
-    # Delete the environment variable if it is loaded
-    if getenv('API_KEY') is not None:
-        del environ['API_KEY']
+        # Delete the environment variable if it is loaded
+        if getenv('API_KEY') is not None:
+            del environ['API_KEY']
 
-    # Start with both keys as None
-    manager.reset_keys()
+        # Start with both keys as None
+        manager.reset_keys()
 
-    return manager
+        return manager
 
 
 def test_request_id_call(manager):

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,44 +1,70 @@
-from os import environ
+from os import environ, getenv
 from unittest.mock import mock_open
+import pytest
 import requests_mock
-from c20_client.get_client_id import IdManager
+from c20_client.get_client_id import (
+    ClientManager,
+    save_client_env_variable
+)
 
 CLIENT_ID = '1234'
-MANAGER = IdManager()
+API_KEY = 'xxxx-xyz-xxxx'
 
 
-def test_request_id_call():
+@pytest.fixture(name="manager")
+def fixture_client_manager_unset(mocker):
+    mocker.patch('c20_client.get_client_id.open', mock_open())
+
+    manager = ClientManager()
+
+    # Delete the environment variable if it is loaded
+    if getenv('CLIENT_ID') is not None:
+        del environ['CLIENT_ID']
+
+    # Delete the environment variable if it is loaded
+    if getenv('API_KEY') is not None:
+        del environ['API_KEY']
+
+    # Start with both keys as None
+    manager.reset_keys()
+
+    return manager
+
+
+def test_request_id_call(manager):
     with requests_mock.Mocker() as mock:
         mock.get('http://capstone.cs.moravian.edu/get_user_id',
                  json={'user_id': CLIENT_ID})
 
-        client_id = MANAGER.request_id()
+        client_id = manager.request_id()
         history = mock.request_history
 
         assert len(history) == 1
         assert 'capstone' in history[0].url
         assert client_id == CLIENT_ID
+        assert manager.client_id == CLIENT_ID
 
 
 def test_write_env_variable(mocker):
     file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
-    MANAGER.save_client_env_variable(CLIENT_ID)
+    save_client_env_variable(CLIENT_ID)
     file_mock.assert_called_once_with('.env', 'a+')
     file_mock().write.assert_called_once_with("CLIENT_ID=" + CLIENT_ID + "\n")
 
 
-def test_id_not_exist_in_env():
-    assert not MANAGER.client_has_id()
-    assert MANAGER.get_id() is None
+def test_id_not_exist_in_env(manager):
+    manager.reset_keys()
+    assert not manager.client_has_id()
+    assert manager.client_id is None
 
 
-def tests_check_not_in_environment(mocker):
+def tests_check_not_in_environment(mocker, manager):
     with requests_mock.Mocker() as mock:
         mock.get('http://capstone.cs.moravian.edu/get_user_id',
                  json={'user_id': CLIENT_ID})
         file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
 
-        MANAGER.check()
+        manager.check_for_id()
         history = mock.request_history
 
         assert len(history) == 1
@@ -46,20 +72,32 @@ def tests_check_not_in_environment(mocker):
         file_mock.assert_called_once_with('.env', 'a+')
         file_mock().write.assert_called_once_with(
             "CLIENT_ID=" + CLIENT_ID + "\n")
+        assert manager.client_id == CLIENT_ID
 
 
-def test_id_exist_in_environment():
+def test_id_exist_in_environment(manager):
     environ['CLIENT_ID'] = CLIENT_ID
-    assert MANAGER.client_has_id()
-    assert MANAGER.get_id() == CLIENT_ID
+    manager.reset_keys()
+    assert manager.client_has_id()
+    assert manager.client_id == CLIENT_ID
 
 
-def tests_check_in_environment():
+def tests_check_in_environment(manager):
     with requests_mock.Mocker() as mock:
         mock.get('http://capstone.cs.moravian.edu/get_user_id',
                  json={'user_id': CLIENT_ID})
 
-        MANAGER.check()
+        environ['CLIENT_ID'] = CLIENT_ID
+        manager.reset_keys()
+        manager.check_for_id()
         history = mock.request_history
 
         assert len(history) == 0
+        assert manager.client_id == CLIENT_ID
+
+
+def test_api_key_from_environment(manager):
+    assert manager.api_key is None
+    environ['API_KEY'] = API_KEY
+    manager.reset_keys()
+    assert manager.api_key == API_KEY

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,10 +1,14 @@
 from os import environ
-import requests_mock
 from unittest.mock import mock_open
-import pytest
-from c20_client.get_client_id import request_id, save_client_env_variable, client_has_id
+import requests_mock
+from c20_client.get_client_id import (
+    request_id,
+    save_client_env_variable,
+    client_has_id
+)
 
 CLIENT_ID = '1234'
+
 
 def test_request_id_call():
     with requests_mock.Mocker() as mock:

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -1,9 +1,9 @@
 import requests_mock
-from mock import mock_open, patch, MagicMock
+from unittest.mock import mock_open
 import pytest
-from c20_client.get_client_id import request_id, client_has_id
+from c20_client.get_client_id import request_id, save_client_env_variable
 
-CLIENT_ID = 1234
+CLIENT_ID = '1234'
 
 def test_request_id_call():
     with requests_mock.Mocker() as mock:
@@ -16,3 +16,9 @@ def test_request_id_call():
         assert len(history) == 1
         assert 'capstone' in history[0].url
         assert client_id == CLIENT_ID
+
+def test_write_env_variable(mocker):
+    file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
+    save_client_env_variable(CLIENT_ID)
+    file_mock.assert_called_once_with('.env', 'a+')
+    file_mock().write.assert_called_once_with("CLIENT_ID=" + CLIENT_ID + "\n")

--- a/tests/c20_client/test_get_id.py
+++ b/tests/c20_client/test_get_id.py
@@ -32,7 +32,34 @@ def test_id_not_exist_in_env():
     assert MANAGER.get_id() is None
 
 
+def tests_check_not_in_environment(mocker):
+    with requests_mock.Mocker() as mock:
+        mock.get('http://capstone.cs.moravian.edu/get_user_id',
+                 json={'user_id': CLIENT_ID})
+        file_mock = mocker.patch('c20_client.get_client_id.open', mock_open())
+
+        MANAGER.check()
+        history = mock.request_history
+
+        assert len(history) == 1
+        assert 'capstone' in history[0].url
+        file_mock.assert_called_once_with('.env', 'a+')
+        file_mock().write.assert_called_once_with(
+            "CLIENT_ID=" + CLIENT_ID + "\n")
+
+
 def test_id_exist_in_environment():
     environ['CLIENT_ID'] = CLIENT_ID
     assert MANAGER.client_has_id()
     assert MANAGER.get_id() == CLIENT_ID
+
+
+def tests_check_in_environment(mocker):
+    with requests_mock.Mocker() as mock:
+        mock.get('http://capstone.cs.moravian.edu/get_user_id',
+                 json={'user_id': CLIENT_ID})
+
+        MANAGER.check()
+        history = mock.request_history
+
+        assert len(history) == 0


### PR DESCRIPTION
In the testing, it would load from the actual .env file as I can not find a way to mock the load and get from the .env. To directly combat this I have a pyfixture that will take care of removing the environment variables. In case somebody does not understand what that means, the function getenv does not grab directly from the .env file. The load_dotenv function puts everything in the .env into a key value pair where the getenv actually grabs from. When it loads the key/values, I delete them from where the getenv grabs from, effectively starting at a "blank slate" for the tests. I hope I explained this well enough, if there is any questions I can probably explain better in person.