### PR TITLE
Fix incorrect attribute definition

### DIFF
--- a/src/c20_server/job_manager.py
+++ b/src/c20_server/job_manager.py
@@ -7,7 +7,7 @@ from c20_server.job import NoneJob
 class JobManager:
 
     def __init__(self, database):
-        self.r_database = database
+        self.r_database = database.r_database
         self.job_queue = JobQueue(self.r_database)
         self.in_progress_jobs = InProgress(self.r_database)
 


### PR DESCRIPTION
When attempting to run the flask_server.py on the deploy server, the object Database didn't recognize the rpush() command, I noticed that when we instantiate a job manager we were setting the attribute r_database equal to the entire Database object, and not the actual variable within the Database object that we assigned to the redis database. 