### PR TITLE
Job translator keyerror fix

### DIFF
--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -66,8 +66,6 @@ def json_to_job(json_job):
     Record = namedtuple('Record', 'job_id job_type')
     input_array_line = [job_id, job_type]
     record = Record(*input_array_line)
-    if record.job_type == NONE_JOB:
-        return create_none_job(record)
     return add_specific_job_data(record, json_job)
 
 
@@ -110,7 +108,3 @@ def create_download_job(record, json_job):
     file_type = json_job["file_type"]
     url = json_job["url"]
     return DownloadJob(record.job_id, folder_name, file_name, file_type, url)
-
-
-def create_none_job(record):
-    return NoneJob(record.job_id)

--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -47,7 +47,7 @@ def handle_jobs(json_data):
         json_data = json.loads(json_data)
     except TypeError:
         return {}
-    
+
     try:
         json_jobs = json_data["jobs"]
     except KeyError:
@@ -66,7 +66,8 @@ def json_to_job(json_job):
     Record = namedtuple('Record', 'job_id job_type')
     input_array_line = [job_id, job_type]
     record = Record(*input_array_line)
-
+    if record.job_type == NONE_JOB:
+        return create_none_job(record)
     return add_specific_job_data(record, json_job)
 
 

--- a/src/c20_server/job_translator.py
+++ b/src/c20_server/job_translator.py
@@ -47,8 +47,11 @@ def handle_jobs(json_data):
         json_data = json.loads(json_data)
     except TypeError:
         return {}
-
-    json_jobs = json_data["jobs"]
+    
+    try:
+        json_jobs = json_data["jobs"]
+    except KeyError:
+        return {}
 
     for job in json_jobs:
         job = json_to_job(job)

--- a/tests/test_job_translator.py
+++ b/tests/test_job_translator.py
@@ -134,15 +134,6 @@ def test_single_docket_json_to_job():
     assert test_job == docket_job
 
 
-def test_none_json_to_job():
-    json_example = {
-        "job_type": "none"
-    }
-    test_job = job_translator.json_to_job(json_example)
-    docket_job = job.NoneJob(test_job[0])
-    assert test_job == docket_job
-
-
 def test_single_download_json_to_job():
     url = "https://api.data.gov/regulations/v3/download \
            ?documentId=CMS-2005-0001-0001&contentType=pdf"

--- a/tests/test_job_translator.py
+++ b/tests/test_job_translator.py
@@ -134,6 +134,15 @@ def test_single_docket_json_to_job():
     assert test_job == docket_job
 
 
+def test_none_json_to_job():
+    json_example = {
+        "job_type": "none"
+    }
+    test_job = job_translator.json_to_job(json_example)
+    docket_job = job.NoneJob(test_job[0])
+    assert test_job == docket_job
+
+
 def test_single_download_json_to_job():
     url = "https://api.data.gov/regulations/v3/download \
            ?documentId=CMS-2005-0001-0001&contentType=pdf"
@@ -306,3 +315,25 @@ def test_handle_document_return_data():
             url=url3)
     ]
     assert test_job == job_list
+
+
+def test_json_data_key_error():
+    """
+    KeyError exception is thrown when there is no jobs field
+    supplied in the json return result value from the client.
+    """
+    json_return_data = \
+        {
+            "Data": [
+                {
+                    "folder_name": "CMS/CMS-2005-0001/CMS-2005-0001-0001/",
+                    "file_name": "basic_document.json",
+                    "contents": {}
+                }
+            ]
+        }
+
+    json_return_data = json.dumps(json_return_data)
+    handled_job = job_translator.handle_jobs(json_return_data)
+
+    assert handled_job == {}


### PR DESCRIPTION
I've added a try except block to handling the json data when the jobs attribute does not exist to stop the server from producing 500 server errors. Also I've added a small test for jobs with type 'none' so that we once again have full pytest coverage in job_translator.py